### PR TITLE
Feat #10 평가할 음식 리스트 API

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should return "Good! 👍 👍"', () => {
+      expect(appController.healthCheck()).toBe('Good! 👍 👍');
     });
   });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
 
-@Controller('/api/v1')
+@Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
 
-@Controller()
+@Controller('/api/v1')
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): string {
-    return this.appService.getHello();
+  healthCheck(): string {
+    return this.appService.healthCheck();
   }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class AppService {
-  getHello(): string {
-    return 'Hello World!';
+  healthCheck(): string {
+    return 'Good! 👍 👍';
   }
 }

--- a/src/food/dto/create-food.dto.ts
+++ b/src/food/dto/create-food.dto.ts
@@ -1,1 +1,21 @@
-export class CreateFoodDto {}
+import { IsBoolean, IsDate, IsString } from 'class-validator';
+
+export class CreateFoodDto {
+  @IsString()
+  readonly id: string;
+
+  @IsString()
+  readonly name: string;
+
+  @IsDate()
+  readonly createdAt: Date;
+
+  @IsDate()
+  readonly deletedAt: Date;
+
+  @IsBoolean()
+  readonly isDeleted: boolean;
+
+  @IsString()
+  readonly imageUrl: string;
+}

--- a/src/food/dto/create-restaurant.dto.ts
+++ b/src/food/dto/create-restaurant.dto.ts
@@ -1,0 +1,42 @@
+import { IsBoolean, IsNumber, IsString, IsDate } from 'class-validator';
+
+export class CreateRestaurantDto {
+  @IsString()
+  id: string;
+
+  @IsString()
+  name: string;
+
+  @IsDate()
+  createdAt: Date;
+
+  @IsDate()
+  updatedAt: Date;
+
+  @IsDate()
+  deletedAt: Date;
+
+  @IsBoolean()
+  isDeleted: boolean;
+
+  @IsString()
+  phoneNumber: string;
+
+  @IsString()
+  address: string;
+
+  @IsNumber()
+  mapX: number;
+
+  @IsNumber()
+  mapY: number;
+
+  @IsString()
+  naverMapUrl: string;
+
+  @IsString()
+  kakaoMapUrl: string;
+
+  @IsString()
+  imageUrl: string;
+}

--- a/src/food/dto/update-restaurant.dto.ts
+++ b/src/food/dto/update-restaurant.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateRestaurantDto } from './create-restaurant.dto';
+
+export class UpdateFoodDto extends PartialType(CreateRestaurantDto) {}

--- a/src/food/entities/food.entity.ts
+++ b/src/food/entities/food.entity.ts
@@ -1,3 +1,4 @@
+import { Review } from 'src/review/entities/review.entity';
 import {
   Column,
   Entity,
@@ -8,6 +9,7 @@ import {
   ManyToMany,
   JoinTable,
   ManyToOne,
+  OneToMany,
 } from 'typeorm';
 import { Category } from './category.entity';
 import { Restaurant } from './restaurant.entity';
@@ -41,6 +43,11 @@ export class Food {
   categories: Category[];
 
   // 한 음식점에 여러 음식이 속할 수 있다고 가정
-  @ManyToOne(() => Restaurant)
+  // restaurant
+  @ManyToOne((type) => Restaurant, (restaurant) => restaurant.foods)
   restaurant: Restaurant;
+
+  // review
+  @OneToMany((type) => Review, (review) => review.food)
+  reviews: Review[];
 }

--- a/src/food/entities/restaurant.entity.ts
+++ b/src/food/entities/restaurant.entity.ts
@@ -7,8 +7,10 @@ import {
   JoinTable,
   ManyToMany,
   PrimaryGeneratedColumn,
+  OneToMany,
 } from 'typeorm';
 import { Category } from './category.entity';
+import { Food } from './food.entity';
 
 @Entity()
 export class Restaurant {
@@ -55,4 +57,8 @@ export class Restaurant {
   @ManyToMany(() => Category)
   @JoinTable({ name: 'restaurant_category' })
   categories: Category[];
+
+  // food
+  @OneToMany((type) => Food, (food) => food.restaurant)
+  foods: Food[];
 }

--- a/src/food/food.controller.ts
+++ b/src/food/food.controller.ts
@@ -1,34 +1,20 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { FoodService } from './food.service';
-import { CreateFoodDto } from './dto/create-food.dto';
-import { UpdateFoodDto } from './dto/update-food.dto';
+import { Food } from './entities/food.entity';
 
 @Controller('food')
 export class FoodController {
-  constructor(private readonly foodService: FoodService) {}
-
-  @Post()
-  create(@Body() createFoodDto: CreateFoodDto) {
-    return this.foodService.create(createFoodDto);
+  constructor(private readonly foodService: FoodService) {
+    this.foodService = foodService;
   }
 
-  @Get()
-  findAll() {
-    return this.foodService.findAll();
+  @Get('/reviews')
+  async reviewFoodList(): Promise<Food[]> {
+    return this.foodService.findReviewFoods();
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.foodService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateFoodDto: UpdateFoodDto) {
-    return this.foodService.update(+id, updateFoodDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.foodService.remove(+id);
+  @Get('/tests')
+  async testFoodList(): Promise<Food[]> {
+    return this.foodService.findTestFoods();
   }
 }

--- a/src/food/food.module.ts
+++ b/src/food/food.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { FoodService } from './food.service';
 import { FoodController } from './food.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Food } from './entities/food.entity';
+import { Restaurant } from './entities/restaurant.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Food, Restaurant])],
   controllers: [FoodController],
-  providers: [FoodService]
+  providers: [FoodService],
 })
 export class FoodModule {}

--- a/src/food/food.service.ts
+++ b/src/food/food.service.ts
@@ -1,26 +1,23 @@
 import { Injectable } from '@nestjs/common';
-import { CreateFoodDto } from './dto/create-food.dto';
-import { UpdateFoodDto } from './dto/update-food.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Food } from './entities/food.entity';
 
 @Injectable()
 export class FoodService {
-  create(createFoodDto: CreateFoodDto) {
-    return 'This action adds a new food';
+  constructor(
+    @InjectRepository(Food)
+    private readonly foodRepository: Repository<Food>,
+  ) {
+    this.foodRepository = foodRepository;
   }
 
-  findAll() {
-    return `This action returns all food`;
+  async findReviewFoods(): Promise<Food[]> {
+    const foodList = await this.foodRepository.find();
+    return foodList;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} food`;
-  }
-
-  update(id: number, updateFoodDto: UpdateFoodDto) {
-    return `This action updates a #${id} food`;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} food`;
+  async findTestFoods(): Promise<Food[]> {
+    return await this.foodRepository.find();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,9 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const port = 3000;
 
+  const prefix = '/api/v1';
+  app.setGlobalPrefix(prefix);
+
   const config = new DocumentBuilder()
     .setTitle('Mab Master Server API')
     .setDescription('Mab Master API 명세서')

--- a/src/review/entities/review.entity.ts
+++ b/src/review/entities/review.entity.ts
@@ -37,10 +37,10 @@ export class Review {
   tasteReviews: TasteTag[];
 
   // Food
-  @ManyToOne(() => Food, { primary: true })
+  @ManyToOne(() => Food, (food) => food.reviews, { primary: true })
   food: Food;
 
   // User
-  @ManyToOne(() => User, { primary: true })
+  @ManyToOne(() => User, (user) => user.reviews, { primary: true })
   user: User;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,3 +1,4 @@
+import { Review } from 'src/review/entities/review.entity';
 import {
   Entity,
   Column,
@@ -6,6 +7,7 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
   ManyToOne,
+  OneToMany,
 } from 'typeorm';
 import { UserLevel } from './user_level.entity';
 
@@ -61,4 +63,8 @@ export class User {
 
   @ManyToOne(() => UserLevel)
   userLevel!: UserLevel;
+
+  // review
+  @OneToMany(() => Review, (review) => review.user)
+  reviews: Review[];
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -58,7 +58,7 @@ export class User {
   @Column({ type: 'boolean', default: false })
   isDeleted: boolean;
 
-  @Column()
+  @Column({ nullable: true })
   role: string;
 
   @ManyToOne(() => UserLevel)


### PR DESCRIPTION
# 주제

- 평가할 음식 리스트 API

# 작업 완료 내용 (자세히 작성)

- API 주소 변경 ( `server:3000/~` -> `server:3000/api/v1/~`)
- 리뷰받을 음식 리스트 (평가) API 구현 (`/food/reviews`)
- 사용자 레벨 평가용 음식 리스트 API구현 (`/food/tests`)
- OneToMany / ManyToOne관계 코드 수정
- Food / Restaurant DTO선언

# 관련 이슈 번호

- #10 

# 미작업 내용

# 특이사항
- 구현한 api의 경우 `food` Table에 대한 값을 가져오는 부분이여서 service단에서 구현 로직이 똑같으나 차후, 레벨 평가용 음식 리스트 api에 수정이 있을것으로 예상되어 현재 분리해놓은 상태입니다.

# 주의사항

- [ ]
